### PR TITLE
Bugfix/opencv version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__*
 Processed*
 .DS_Store
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-opencv-python==3.3.0.10
+opencv-python>=3.3.0.10,<4.0.0
 matplotlib>=3.1.2
 scikit-learn>=0.22.1
 numpy>=1.18.1


### PR DESCRIPTION
- The opencv-python 3.3.0.10 version didn't work for my python version. However, 3.4.9.31 did work. So I defined a range of valid opencv-python versions in the requirements file.
- Also, assuming 'venv' is the most commonly used name of the virtual environment, I added venv/ to the gitignore.